### PR TITLE
Fixed non-deterministic tests in EnumUtilsTest.java

### DIFF
--- a/src/main/java/org/apache/commons/lang3/EnumUtils.java
+++ b/src/main/java/org/apache/commons/lang3/EnumUtils.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import java.util.LinkedHashMap;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -299,8 +298,7 @@ public class EnumUtils {
      * @since 3.13.0
      */
     public static <E extends Enum<E>, K> Map<K, E> getEnumMap(final Class<E> enumClass, final Function<E, K> keyFunction) {
-        return Stream.of(enumClass.getEnumConstants()).collect(Collectors.toMap(keyFunction::apply, Function.identity(),
-                (oldValue, newValue) -> oldValue, LinkedHashMap::new));
+        return Stream.of(enumClass.getEnumConstants()).collect(Collectors.toMap(keyFunction::apply, Function.identity()));
     }
 
     /**

--- a/src/main/java/org/apache/commons/lang3/EnumUtils.java
+++ b/src/main/java/org/apache/commons/lang3/EnumUtils.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -298,7 +299,8 @@ public class EnumUtils {
      * @since 3.13.0
      */
     public static <E extends Enum<E>, K> Map<K, E> getEnumMap(final Class<E> enumClass, final Function<E, K> keyFunction) {
-        return Stream.of(enumClass.getEnumConstants()).collect(Collectors.toMap(keyFunction::apply, Function.identity()));
+        return Stream.of(enumClass.getEnumConstants()).collect(Collectors.toMap(keyFunction::apply, Function.identity(),
+                (oldValue, newValue) -> oldValue, LinkedHashMap::new));
     }
 
     /**

--- a/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java
@@ -29,6 +29,8 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Assertions;
@@ -340,7 +342,12 @@ public class EnumUtilsTest extends AbstractLangTest {
     @Test
     public void test_getEnumMap() {
         final Map<String, Traffic> test = EnumUtils.getEnumMap(Traffic.class);
-        assertEquals("{RED=RED, AMBER=AMBER, GREEN=GREEN}", test.toString(), "getEnumMap not created correctly");
+        final Map<String, Traffic> expected = new HashMap() {{
+            put("RED", Traffic.RED);
+            put("AMBER", Traffic.AMBER);
+            put("GREEN", Traffic.GREEN);
+        }};
+        assertEquals(expected, test, "getEnumMap not created correctly");
         assertEquals(3, test.size());
         assertTrue(test.containsKey("RED"));
         assertEquals(Traffic.RED, test.get("RED"));
@@ -354,8 +361,21 @@ public class EnumUtilsTest extends AbstractLangTest {
     @Test
     public void test_getEnumMap_keyFunction() {
         final Map<Integer, Month> test = EnumUtils.getEnumMap(Month.class, Month::getId);
-        assertEquals("{1=JAN, 2=FEB, 3=MAR, 4=APR, 5=MAY, 6=JUN, 7=JUL, 8=AUG, 9=SEP, 10=OCT, 11=NOV, 12=DEC}", test.toString(),
-                "getEnumMap not created correctly");
+        final Map<Integer, Month> expected = new HashMap() {{
+            put(1, Month.JAN);
+            put(2, Month.FEB);
+            put(3, Month.MAR);
+            put(4, Month.APR);
+            put(5, Month.MAY);
+            put(6, Month.JUN);
+            put(7, Month.JUL);
+            put(8, Month.AUG);
+            put(9, Month.SEP);
+            put(10, Month.OCT);
+            put(11, Month.NOV);
+            put(12, Month.DEC);
+        }};
+        assertEquals(expected, test, "getEnumMap not created correctly");
         assertEquals(12, test.size());
         assertFalse(test.containsKey(0));
         assertTrue(test.containsKey(1));


### PR DESCRIPTION
Found two failing tests in EnumUtilsTest.java 
Test names: [test_getEnumMap](https://github.com/harshith2000/commons-lang/blob/912ab7154d5280a2632f375b5efd97e1b70149a4/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java#L341), [test_getEnumMap_keyFunction](https://github.com/harshith2000/commons-lang/blob/912ab7154d5280a2632f375b5efd97e1b70149a4/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java#L355)

### Reason for failure: 
The issue we're encountering in the test arises from the nature of the Map collection in Java. The Map returned by the getEnumMap method does not guarantee the order of its elements. 
https://github.com/harshith2000/commons-lang/blob/912ab7154d5280a2632f375b5efd97e1b70149a4/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java#L342
This is especially true when you're using implementations like HashMap, which is what Collectors.toMap() typically uses under the hood. According to the [official documentation](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html), HashMap does not maintain the order of its elements.
https://github.com/harshith2000/commons-lang/blob/912ab7154d5280a2632f375b5efd97e1b70149a4/src/main/java/org/apache/commons/lang3/EnumUtils.java#L301

### Fix: 
Instead of converting the [test map](https://github.com/harshith2000/commons-lang/blob/912ab7154d5280a2632f375b5efd97e1b70149a4/src/test/java/org/apache/commons/lang3/EnumUtilsTest.java#L343) to a string, and then doing an assert check, we can create an expected Map and then compare the two maps. This way, we check whether both maps have the same key-value pairs, but don't consider the order in which these elements are stored.

### Steps to reproduce the behavior:
I used an open-source tool called [NonDex](https://github.com/TestingResearchIllinois/NonDex) to detect the assumption by shuffling the order of returned exception types.
Running the following commands will test the aforementioned operation

**Clone the Repo**
```
https://github.com/apache/commons-lang 
```
**Compile the project**
```
mvn install -am -DskipTests
```
**(Optional) Run the unit test**
```
mvn test -Dtest=org.apache.commons.lang3.EnumUtilsTest#test_getEnumMap_keyFunction
```
**Run the unit test using NonDex**
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.commons.lang3.EnumUtilsTest#test_getEnumMap_keyFunction
```

### Stack trace for additional information:
```
[ERROR] Failures: 
[ERROR]   EnumUtilsTest.test_getEnumMap:343 getEnumMap not created correctly ==> expected: <{RED=RED, AMBER=AMBER, GREEN=GREEN}> but was: <{GREEN=GREEN, RED=RED, AMBER=AMBER}>
[ERROR]   EnumUtilsTest.test_getEnumMap_keyFunction:357 getEnumMap not created correctly ==> expected: <{1=JAN, 2=FEB, 3=MAR, 4=APR, 5=MAY, 6=JUN, 7=JUL, 8=AUG, 9=SEP, 10=OCT, 11=NOV, 12=DEC}> but was: <{8=AUG, 1=JAN, 10=OCT, 12=DEC, 2=FEB, 7=JUL, 6=JUN, 11=NOV, 3=MAR, 5=MAY, 9=SEP, 4=APR}>
```